### PR TITLE
Update Canvas.py to improve canvas component scaling

### DIFF
--- a/sjvisualizer/Canvas.py
+++ b/sjvisualizer/Canvas.py
@@ -168,8 +168,8 @@ class canvas():
         :type color: tuple of length 3 with integers
 
         """
-        title_font = font.Font(family=text_font, size=int(HEIGHT/30/ SCALEFACTOR), weight="bold")
-        self.canvas.create_text(WIDTH/2, HEIGHT/20, font=title_font, text=text, fill=_from_rgb(color))
+        title_font = font.Font(family=text_font, size=int(self.height/30/ SCALEFACTOR), weight="bold")
+        self.canvas.create_text(self.width/2, self.height/20, font=title_font, text=text, fill=_from_rgb(color))
 
     def add_sub_title(self, text, color=(0, 0, 0)):
         """
@@ -182,8 +182,8 @@ class canvas():
         :type color: tuple of length 3 with integers
 
         """
-        title_font = font.Font(family=text_font, size=int(HEIGHT/45/ SCALEFACTOR), weight="bold")
-        self.canvas.create_text(WIDTH/2, HEIGHT/11, font=title_font, text=text, fill=_from_rgb(color))
+        title_font = font.Font(family=text_font, size=int(self.height/45/ SCALEFACTOR), weight="bold")
+        self.canvas.create_text(self.width/2, self.height/11, font=title_font, text=text, fill=_from_rgb(color))
 
     def add_time(self, df, time_indicator="year", color=(150, 150, 150)):
         """
@@ -199,8 +199,8 @@ class canvas():
         :type color: tuple of length 3 with integers
         """
         from sjvisualizer import Date
-        sub_plot = Date.date(canvas=self.canvas, start_time=list(df.index)[0], width=0, height=HEIGHT/12,
-                                       x_pos=WIDTH/10, y_pos=HEIGHT*0.85, time_indicator=time_indicator,
+        sub_plot = Date.date(canvas=self.canvas, start_time=list(df.index)[0], width=0, height=self.height/12,
+                                       x_pos=self.width/10, y_pos=self.height*0.85, time_indicator=time_indicator,
                                        font_color=color)
         self.add_sub_plot(sub_plot)
 
@@ -212,8 +212,8 @@ class canvas():
         :type str
         """
         from sjvisualizer import StaticImage
-        img = StaticImage.static_image(canvas=self.canvas, width=int(WIDTH/15), height=int(WIDTH/15), x_pos=WIDTH*0.95,
-                                           y_pos=HEIGHT*0.00,
+        img = StaticImage.static_image(canvas=self.canvas, width=int(self.width/15), height=int(self.width/15), x_pos=self.width*0.95,
+                                           y_pos=self.height*0.00,
                                            file=logo, root=self.tk, anchor="ne")
         self.add_sub_plot(img)
 


### PR DESCRIPTION
Use self.height and self.width in place of HEIGHT & WIDTH within the 'add_*' methods for canvas objects so added plot components (e.g. title, subtitle, time) scale their positions relative to the canvas size, rather than the monitor size