### PR TITLE
Fix: Resolve KeyError 0 in DataHandler.py for Pandas 3.0+ Compatibility

### DIFF
--- a/sjvisualizer/DataHandler.py
+++ b/sjvisualizer/DataHandler.py
@@ -12,10 +12,11 @@ class DataHandler():
     :param number_of_frames: number of frames in your animation. Typically you want to aim for 60*FPS*Duration
     :type number_of_frames: int
     """
-    def __init__(self, excel_file=None, number_of_frames=0, log_scale=False):
+    def __init__(self, excel_file=None, number_of_frames=0, log_scale=False, nrows = None):
         self.excel_file = excel_file
         self.number_of_frames = number_of_frames + 7
         self.log_scale = log_scale
+        self.nrows = nrows
 
         # try to find cached location of the file
         try:
@@ -29,11 +30,11 @@ class DataHandler():
             self._load_file()
         else:
             print("loading new data frame")
-            self.df = pd.read_excel(excel_file, index_col=[0])
+            self.df = pd.read_excel(excel_file, index_col=[0], nrows = self.nrows)
             self._prep_data()
 
     def _load_file(self):
-        self.df = pd.read_excel(self.cache_location, index_col=[0])
+        self.df = pd.read_excel(self.cache_location, index_col=[0], nrows = self.nrows)
         self.df = self.df.loc[:, ~self.df.columns.str.contains('^Unnamed')]
 
     def _prep_data(self):
@@ -111,12 +112,14 @@ class DataHandler():
 
 class SizeCompareDataHandler():
 
-    def __init__(self, excel_file=None, number_of_frames=0, area = True):
+    def __init__(self, excel_file=None, number_of_frames=0, area = True, nrows = None):
         self.excel_file = excel_file
         self.number_of_frames = number_of_frames
-
-        self.df = pd.read_excel(excel_file)
+        self.nrows = nrows
         self.area = area
+
+        self.df = pd.read_excel(excel_file, nrows = self.nrows)
+       
 
         # speed of the smooth transition
         self.w = 0.1

--- a/sjvisualizer/DataHandler.py
+++ b/sjvisualizer/DataHandler.py
@@ -69,7 +69,7 @@ class DataHandler():
         print("Setting column to numerical value for interpolation")
         # set columns to numeric values for interpolation
         for col in temp_df:
-            if not isinstance(temp_df[col][0], str):
+            if not isinstance(temp_df[col].iloc[0], str):
                 try:
                     temp_df[col] = pd.to_numeric(temp_df[col])
                 except ValueError:


### PR DESCRIPTION
This PR fixes a bug where DataHandler crashes when loading data in environments running pandas 3.0 or higher.

Because pandas 3.0 changed integer indexing to strictly look for labels rather than positions, "temp_df[col][0]" throws a KeyError. Updating this to ".iloc[0]" ensures the first row is selected positionally, maintaining backward compatibility while fixing the crash for modern setups where integer keys are treated strictly as labels (GH#50617).